### PR TITLE
Properly exclude tests from install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author='5j9',
     author_email='5j9@users.noreply.github.com',
     license='GNU General Public License v3 (GPLv3)',
-    packages=find_packages(exclude='tests'),
+    packages=find_packages(exclude=['tests']),
     python_requires='>=3.4',
     install_requires=[
         'regex',


### PR DESCRIPTION
Currently setup.py not excluding tests subdirectory. find_packages's
exclude should recieve list of directories, no directory itself.