### PR TITLE
#27 added tag start position arg to regex.search for tag end

### DIFF
--- a/wikitextparser/_wikitext.py
+++ b/wikitextparser/_wikitext.py
@@ -1011,7 +1011,7 @@ class WikiText:
                     end_match = search(
                         END_TAG_PATTERN.replace(
                             b'{name}', start_match['name']),
-                        shadow_copy)
+                        shadow_copy, pos=start_match.end())
                 if end_match:
                     s, e = end_match.span()
                     shadow_copy[s:e] = b'_' * (e - s)


### PR DESCRIPTION
Fix for issue #27 

Multiple tags with the same name on a single line are now parsed correctly:
```
>>> wt_obj = WikiText('March 20, 2018 <small>(Part 1)</small> <br/> March 27, 2018 <small>(Part 2)</small>')

>>> wt_obj.tags()[0]
Tag('<small>(Part 1)</small>')

>>> wt_obj.tags()[1]
Tag('<br/>')

>>> wt_obj.tags()[2]
Tag('<small>(Part 2)</small>')
```