### PR TITLE
Fix for link text ending in ]

### DIFF
--- a/wikitextparser/_spans.py
+++ b/wikitextparser/_spans.py
@@ -89,7 +89,7 @@ WIKILINK_FINDITER = regex_compile(
             |
             \](?!\])
         )*+
-        \]\]
+        \]{2,3}
     )
     ''',
     IGNORECASE | VERBOSE).finditer


### PR DESCRIPTION
This seems like the safest / most accurate solution.  The WikiLink properties continue to produce the expected results with this change.