### PR TITLE
fix(ATTR_VAL): allow empty attrs with trailing space

### DIFF
--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -139,6 +139,11 @@ def test_attrs():
         'n1': 'v1', 'n2': 'v2', 'n3': ''}
 
 
+def test_attrs_without_values():
+    assert Tag('<t n1 n2 n3>c</t>').attrs == {
+        'n1': '', 'n2': '', 'n3': ''}
+
+
 def test_contents_contains_tl():
     t = Tag('<b>{{text|t}}</b>')
     assert t.contents == '{{text|t}}'

--- a/wikitextparser/_spans.py
+++ b/wikitextparser/_spans.py
@@ -146,7 +146,7 @@ ATTR_VAL = (
     # If an empty attribute is to be followed by the optional
     # "/" character, then there must be a space character separating
     # the two. This rule is ignored here.
-    rb'[' + SPACE_CHARS + rb']*+(?>'  # noqa
+    rb'(?>[' + SPACE_CHARS + rb']*+'  # noqa
         + EQ_WS + rb'(?>' + UNQUOTED_ATTR_VAL + rb'|' + QUOTED_ATTR_VAL + rb')'
         + rb'|(?<attr_value>)'  # empty attribute
     + rb')')


### PR DESCRIPTION
parsing spaces before empty attributes
makes the parsing of subsequent attributes
fail as the whitespace at the start is missing.

closes #44 