### PR TITLE
fix(_table): pipe in cell value made parts of the value be seen as attrs

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -413,7 +413,7 @@ def test_multiline_table():
     table.del_attr('s')
     table.set_attr('class', 'wikitable')
     assert repr(table) == "Table('{| class=\"wikitable\"\\n|a\\n|}')"
-    
+
     assert table.get_attr('class') == 'wikitable'
     table.set_attr('class', 'sortable')
     assert table.attrs == {'class': 'sortable'}
@@ -428,6 +428,11 @@ def test_attr_contains_template_newline_invalid_chars():
         '| cell\n'
         '|}\n'
     ).tables[0].get_attr('style') == 'color: {{text| 1 =\nred}};'
+
+
+def test_pipe_in_text():
+    table = Table('{|\n| colspan="2" | text | with pipe\n|}')
+    assert table.cells()[0][0].attrs == {"colspan": "2"}
 
 
 # Table.cells

--- a/wikitextparser/_cell.py
+++ b/wikitextparser/_cell.py
@@ -24,7 +24,7 @@ NEWLINE_CELL_MATCH = regex_compile(
         |
         (?P<attrs>
             (?:
-                [^\n]
+                [^|\n]
                 (?!
                     # attrs end with `|`; or `!!` if sep is `!`
                     (?P=sep){2}|\|\|


### PR DESCRIPTION
Because I don't like only creating issues in projects, let me try a fix of an issue :D

The code that went wrong, was an invalid `[[ ]]` inside a table:

```python
import wikitextparser

wtp = wikitextparser.parse('{|\n| colspan="2" | [[File:<|32px]] \n|}')
print(wtp.get_tables()[0].cells()[0][0].attrs)
```

Returns
```
{'colspan': '2', '|': '', '[[File:<': ''}
```

Because of the `<` in the `[[ ]]`, it is not sees as wikilink (which makes sense to me), but it does leave a `|` in the value of a cell. Because the regex `attrs` is greedy, it reads till the last `|` instead of the first.

I think this is the correct fix for this problem, but I cannot see if there are legit cases that will fail now.