### PR TITLE
fix(is_header): cells starting with | are not header-cells

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -520,6 +520,11 @@ def test_cell_header():
         row=0, column=1).is_header is True
 
 
+def test_not_cell_header():
+    assert Table('{|\n!Header\n|Not a header|}').cells(
+        row=0, column=1).is_header is False
+
+
 def test_table_attr_span_false():  # 71
     cell = Table('{|\n|colspan=2| Test1 \n|| Test 2 \n|| Test 3 \n|}').cells(
         span=False)[0][0]

--- a/wikitextparser/_cell.py
+++ b/wikitextparser/_cell.py
@@ -63,10 +63,14 @@ INLINE_HAEDER_CELL_MATCH = regex_compile(
     rb"""
     (?>
         # immediate closure of attrs
-        \|!(?P<attrs>)!
+        (?P<sep>\|)!(?P<attrs>)!
         |
         # attrs start is with a double ! or |
-        (?>!{2}|\|{2})
+        (?>
+            (?P<sep>!)!
+            |
+            (?P<sep>\|)\|
+        )
         # find the matching pipe that ends attrs
         (?>
             # immediate closure
@@ -106,7 +110,7 @@ INLINE_HAEDER_CELL_MATCH = regex_compile(
 # https://regex101.com/r/hW8aZ3/7
 INLINE_NONHAEDER_CELL_MATCH = regex_compile(
     rb"""
-    \|\| # catch the matching pipe (style holder).
+    (?P<sep>\|)\| # catch the matching pipe (style holder).
     (?>
         # immediate closure
         (?P<attrs>)

--- a/wikitextparser/_table.py
+++ b/wikitextparser/_table.py
@@ -213,12 +213,12 @@ class Table(SubWikiTextWithAttrs):
         for match_row in match_table:
             row_cells = []  # type: List[Cell]
             table_cells.append(row_cells)
-            header = match_row[0]['sep'] == b'!'
             if span:
                 row_attrs = []  # type: List[Dict[str, str]]
                 table_attrs.append(row_attrs)
                 row_attrs_append = row_attrs.append
             for m in match_row:
+                header = m['sep'] == b'!'
                 ms, me = m.span()
                 cell_span = [ss + ms, ss + me, None, shadow[ms:me]]
                 if span:


### PR DESCRIPTION
```python
import wikitextparser

wtp = wikitextparser.parse("{|\n! Header\n| Not a header\n|}")
print(wtp.get_tables()[0].cells()[0][1].is_header)
```

Prints `True`, but it really is not a header (https://www.mediawiki.org/wiki/Help:Tables#Accessibility_of_table_header_cells).

The problem seems to be that currently the first cell in a row decides if a whole row should be a header or not (if I understand the code correctly). This is not true. I now changed the regex to tell per cell if it is a header or not.

There might already have been code on https://github.com/5j9/wikitextparser/blob/master/wikitextparser/_cell.py#L186 that is suppose to do this; but this code is never executed in the above example. So please check this PR with care :)