### PR TITLE
fix(wikilink): empty wikilinks are internally not replaced with _

### DIFF
--- a/tests/test_parser_function.py
+++ b/tests/test_parser_function.py
@@ -44,6 +44,11 @@ def test_pipes_inside_params_or_templates():
     assert 2 == len(pf.arguments)
 
 
+def test_strip_empty_wikilink():
+    pf = ParserFunction("{{ #if: test | [[|Alt]] }}")
+    assert 2 == len(pf.arguments)
+
+
 def test_default_parser_function_without_hash_sign():
     assert 1 == len(WikiText("{{formatnum:text|R}}").parser_functions)
 

--- a/wikitextparser/_spans.py
+++ b/wikitextparser/_spans.py
@@ -10,7 +10,7 @@ from ._config import (
 
 # According to https://www.mediawiki.org/wiki/Manual:$wgLegalTitleChars
 # illegal title characters are: r'[]{}|#<>[\u0000-\u0020]'
-VALID_TITLE_CHARS = rb'[^\|\{\}\[\]<>\n]++'
+VALID_TITLE_CHARS = rb'[^\|\{\}\[\]<>\n]*+'
 # Parser functions
 # According to https://www.mediawiki.org/wiki/Help:Magic_words
 # See also:


### PR DESCRIPTION
"[[|alt]]" is a valid wikilink, but WIKILINK_PARAM_FINDITER did not
consider it valid. In result, it was seens as a wikilink, but not
marked as _ for, as example, a parser function to handle it. This
meant a parser function saw "alt ]]" as another argument, where it
really was not.

This was a very interesting one to track down. `VALID_TITLE_CHARS` is also used by `PF_TL_FINDITER`, which now also  has its behaviour changed. As I am not fluent in reading regex (is anyone really?), I am not sure what the side-effect of that is.

Alternative, the `++` and `*+` marker could be moved outside of `VALID_TITLE_CHARS`, keeping `PF_TL_FINDITER` the same in behaviour. Let me know if you prefer this.

Ironically, mediawiki has a bug here, where the given test-case works fine, but if the wikilink is `[[{{{empty}}}|Alt]]` it does fail. `wikitextparser`, with this PR, does the right thing here too now.