### PR TITLE
add(_table): support multiline captions

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -515,6 +515,14 @@ def test_caption_containing_piped_wikilink():
     assert Table('{|\n|+a [[b|c]]\n|}').caption == 'a [[b|c]]'
 
 
+def test_caption_multiline():
+    assert Table('{|\n|+a\nb\nc\n|}').caption == "a\nb\nc"
+
+
+def test_caption_multiline_rows():
+    assert Table('{|\n|+a\nb\nc\n|-\n|cell\n|}').caption == "a\nb\nc"
+
+
 def test_cell_header():
     assert Table('{|\n!1!!style="color:red;"|2\n|}').cells(
         row=0, column=1).is_header is True

--- a/wikitextparser/_table.py
+++ b/wikitextparser/_table.py
@@ -4,7 +4,7 @@
 from bisect import insort_right
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
-from regex import VERBOSE, compile as regex_compile
+from regex import DOTALL, VERBOSE, compile as regex_compile
 
 from ._cell import (
     Cell, INLINE_HAEDER_CELL_MATCH, INLINE_NONHAEDER_CELL_MATCH,
@@ -35,8 +35,8 @@ CAPTION_MATCH = regex_compile(
         (?!\|)
     )?
     (?P<caption>.*?)
-    (?:\n|\|\|)
-    """, VERBOSE).match
+    (?:\n[\|\!])
+    """, DOTALL | VERBOSE).match
 T = TypeVar('T')
 
 


### PR DESCRIPTION
I found another nice edge-case. This mostly happen when people use templates in captions, but from what I can tell, captions can be multiline (at least, testing on mediawiki shows it is working fine). For example:

```
{|
|+
caption line 1
caption line 2
|}
```

Generates the HTML

```
<caption>
caption line 1
caption line 2
</caption>
```

This PR allows for that scenario to exist.

The original regex also closed the caption when it found `||`; mediawiki does render a cell in those cases for the text following, but the library currently does not pick it up as a cell. So I was a bit uncertain what to dot in those cases .. so instead I removed that part of the regex. Example:

```
{|
|+ caption || cell
|}
```

Not sure what the expected outcome should be.