### PR TITLE
fix(_wikilist): items and fullitems could have members flipped

### DIFF
--- a/tests/test_wikilist.py
+++ b/tests/test_wikilist.py
@@ -97,6 +97,12 @@ def test_mixed_definition_lists():
             'back to the main list']
 
 
+def test_order_definition_lists():
+    wl = WikiList("; Item 1 : definition 1\n", pattern=r'[:;]\s*')
+    assert wl.items == ["Item 1 ", " definition 1"]
+    assert wl.fullitems == ["; Item 1 : definition 1\n", ": definition 1"]
+
+
 def test_travese_mixed_list_completely():
     wl = WikiList(
         '* Or create mixed lists\n'

--- a/wikitextparser/_wikilist.py
+++ b/wikitextparser/_wikilist.py
@@ -91,7 +91,9 @@ class WikiList(SubWikiText):
         string = self.string
         match = self._match
         ms = match.start()
-        for s, e in match.spans('fullitem'):
+        # Sort because "fullitem" can be flipped compared to "items" in case
+        # of a definition list with the LIST_PATTERN_FORMAT regex.
+        for s, e in sorted(match.spans('fullitem')):
             append(string[s - ms:e - ms])
         return fullitems
 


### PR DESCRIPTION
For definitions lists, the LIST_PATTERN_FORMAT regex matches two
fullitems and two items. Only the order of those are flipped from
each other. This is because the first item in the regex is the
first match("item"), and the second is the second. For the
fullitem however, it is the other way around, as everything is
part of the first fullitem.

Fixes #72

-----

Possibly this can also be fixed in the regular expression, but I wouldn't know how :)

I am also not sure if `fullitems[0]` should contain the `definition 1` part; it doesn't hurt at least.