### PR TITLE
fix(_wikilist): allow :// links in the item of a definition list

### DIFF
--- a/tests/test_wikilist.py
+++ b/tests/test_wikilist.py
@@ -79,6 +79,11 @@ def test_subitems_for_the_second_item():
     assert sublist.items == [' sub-list of b']
 
 
+def test_link_in_definition_list():
+    wl = WikiList("; https://github.com : definition", pattern=r'[:;]\s*')
+    assert wl.items == ["https://github.com ", " definition"]
+
+
 def test_mixed_definition_lists():
     wl = WikiList(
         '; Mixed definition lists\n'

--- a/wikitextparser/_wikilist.py
+++ b/wikitextparser/_wikilist.py
@@ -3,7 +3,7 @@ from warnings import warn
 
 from regex import MULTILINE, escape, fullmatch
 
-from ._wikitext import SubWikiText
+from ._wikitext import BRACKET_EXTERNAL_LINK_SCHEMES, SubWikiText
 
 SUBLIST_PATTERN = (  # noqa
     rb'(?>^'
@@ -16,7 +16,11 @@ LIST_PATTERN_FORMAT = (  # noqa
         rb'(?<pattern>{pattern})'
         rb'(?(?<=;\s*+)'
             # mark inline definition as an item
-            rb'(?<item>[^:\n]*+)(?<fullitem>:(?<item>.*+))?+'
+            rb'(?<item>'
+                rb'.*' + BRACKET_EXTERNAL_LINK_SCHEMES + rb'[^:\n]*+'
+                rb'|'
+                rb'[^:\n]*+'
+            rb')(?<fullitem>:(?<item>.*+))?+'
             rb'(?>\n|\Z)' + SUBLIST_PATTERN +
             rb'|'
             # non-definition


### PR DESCRIPTION
This is a very minor case to improve definition lists slightly.

I am not totally sure about this solution, as it only allows a single link .. so how about 2? or 3? But my regular expression knowledge is not good enough, and I was mostly curious if this was something that would be a good idea.

Possibly there are better ways, like the way you use shadow for other elements.