### PR TITLE
fix(get_tags): using name= fails for extensiontags without attributes

### DIFF
--- a/tests/test_wikitext.py
+++ b/tests/test_wikitext.py
@@ -1222,6 +1222,11 @@ def test_same_nested_tags():
     assert all_tags[1].string == tags_by_name[1].string
 
 
+def test_tag_extension_by_name():
+    parsed = parse('<gallery>pictures</gallery>')
+    assert parsed.get_tags('gallery')[0].contents == "pictures"
+
+
 def test_self_closing():
     # extension tag
     assert parse('<references />').get_tags()[0].string == '<references />'

--- a/wikitextparser/_wikitext.py
+++ b/wikitextparser/_wikitext.py
@@ -1272,7 +1272,7 @@ class WikiText:
         if name:
             if name in _tag_extensions:
                 string = lststr[0]
-                startswith = '<' + name + ' '
+                startswith = ('<' + name + ' ', '<' + name + '>')
                 return [
                     Tag(lststr, type_to_spans, span, 'ExtensionTag')
                     for span in type_to_spans['ExtensionTag']


### PR DESCRIPTION
This happens often for `<gallery>` tags, as example.