### PR TITLE
fix(plain_text): partition is not distinguishing file extensions correctly

### DIFF
--- a/wikitextparser/_wikitext.py
+++ b/wikitextparser/_wikitext.py
@@ -740,7 +740,7 @@ class WikiText:
                 b, e = w.span
                 title = w.title
                 if title[:1] != ':' and (
-                    title.partition(':')[2].partition('.')[2]
+                    title.partition(':')[2].rpartition('.')[2]
                     in KNOWN_FILE_EXTENSIONS
                 ):
                     remove(b, e)  # image


### PR DESCRIPTION
```python
if replace_wikilinks:
            for w in parsed.wikilinks:
                b, e = w.span
                title = w.title
                if title[:1] != ':' and (
                    title.partition(':')[2].partition('.')[2]
                    in KNOWN_FILE_EXTENSIONS
                ):
                    remove(b, e)  # image
```

At line 743 of _wikitext.py, it calls partition to separate the extension from the file name. However, in this case, if the file name contains '.', the extension cannot be obtained correctly.

For example, [[File:Julia set (C = 0.285, 0.01).jpg]] is not recognized as a file because the extension is separated by '285, 0.01).jpg', and this problem is solved simply by replacing partition with rpartition.