### PR TITLE
Fix malformed section titles when multiple levels are added

### DIFF
--- a/wikitextparser/_section.py
+++ b/wikitextparser/_section.py
@@ -44,7 +44,7 @@ class Section(SubWikiText):
         if level_diff < 0:
             new_equals = '=' * abs(level_diff)
             self.insert(0, new_equals)
-            self.insert(m.end(2) + 1, new_equals)
+            self.insert(m.end(2) + abs(level_diff), new_equals)
             return
         del self[:level_diff]
         del self[m.end(2) : m.end(2) + level_diff]


### PR DESCRIPTION
Previously, when changing the level of a section, adding additional  `=`s  to the end of a section title didn't take into account that the index of the end of the section title changes based on how many `=`s were added to the start of the section title. This created malformed section titles when doing things like `section.level += 2`.