### PR TITLE
Fix filetype comparison in plain_text method

### DIFF
--- a/wikitextparser/_wikitext.py
+++ b/wikitextparser/_wikitext.py
@@ -725,7 +725,7 @@ class WikiText:
                 b, e = w.span
                 title = w.title
                 if title[:1] != ':' and (
-                    title.partition(':')[2].rpartition('.')[2]
+                    title.partition(':')[2].rpartition('.')[2].lower()
                     in KNOWN_FILE_EXTENSIONS
                 ):
                     remove(b, e)  # image


### PR DESCRIPTION
The plain_text method in _wikitext.py uses the KNOWN_FILE_EXTENSIONS list to compare file types. When comparing capitalization was NOT ignored and thus images with .JPG or .PNG extensions were not detected. 

In [@wikimedia/mediawiki](https://github.com/wikimedia/mediawiki/) they [use strtolower()](https://github.com/wikimedia/mediawiki/blob/master/includes/libs/mime/MimeAnalyzer.php#L438) in the PHP code which was probably overlooked when creating the plain_text method here.

A simple .lower() should fix this.