### PR TITLE
Added documentation for filtering categories from WikiLinks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,20 +113,23 @@ WikiLinks
     >>> wl
     WikiLink('[[new_title#new_fragmet]]')
 
-All WikiLink properties support get, set, and delete operations. Categories are special cases of WikiLinks, in that they are prefixed with the category namespace:
+All WikiLink properties support get, set, and delete operations. Categories are special cases of WikiLinks, in that they are prefixed with the category namespace, which is case insensitive and may be internationalized:
 
 .. code:: python
 
     >>> parsed = wtp.parse("""
         [[Category:Foo]]
-        [[Category:Bar]]
+        [[Κατηγορία:Bar]]
         [[Other link]]
         """)
     >>> categories = [
             wl
             for wl
             in parsed.wikilinks
-            if wl.title.partition(':')[0].strip() == "Category"
+            if wl.title.partition(':')[0]
+                .strip()
+                .lower()
+                in ["category", "κατηγορία"]
         ]
     >>> categories
     [WikiLink('[[Category:Foo]]'), WikiLink('[[Category:Bar]]')]

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,23 @@ WikiLinks
     >>> wl
     WikiLink('[[new_title#new_fragmet]]')
 
-All WikiLink properties support get, set, and delete operations.
+All WikiLink properties support get, set, and delete operations. Categories are special cases of WikiLinks, in that they are prefixed with the category namespace:
+
+.. code:: python
+
+    >>> parsed = wtp.parse("""
+        [[Category:Foo]]
+        [[Category:Bar]]
+        [[Other link]]
+        """)
+    >>> categories = [
+            wl
+            for wl
+            in parsed.wikilinks
+            if wl.title.partition(':')[0].strip() == "Category"
+        ]
+    >>> categories
+    [WikiLink('[[Category:Foo]]'), WikiLink('[[Category:Bar]]')]
 
 Sections
 --------


### PR DESCRIPTION
Added a note in `README.rst` for how to get the categories out of the list of WikiLinks. This is what it looks like when rendered by Sphinx:

![sphinx-docs-screenshot-2](https://github.com/user-attachments/assets/29800b89-8e79-4230-a2da-ffdc6247af55)

Closes #142 
