### PR TITLE
Fix tag parsing (again)

### DIFF
--- a/wikitextparser/_spans.py
+++ b/wikitextparser/_spans.py
@@ -151,9 +151,9 @@ CONTROL_CHARS = rb'\x00-\x1f\x7f-\x9f'
 # https://www.w3.org/TR/html5/syntax.html#syntax-attributes
 ATTR_NAME = rb'(?<attr_name>[^' + SPACE_CHARS + CONTROL_CHARS + rb'"\'>/=]++)'
 EQ_WS = rb'[=\1][' + SPACE_CHARS + rb']*+'
-UNQUOTED_ATTR_VAL = rb'(?<attr_value>[^' + SPACE_CHARS + rb'"\'=<>`]++)'
-DOUBLE_QUOTED_ATTR_VAL = rb'"(?<attr_value>[^"<>]*)"?(?<!/)'
-SINGLE_QUOTED_ATTR_VAL = rb'\'(?<attr_value>[^\'<>]*)\'?(?<!/)'
+UNQUOTED_ATTR_VAL = rb'(?<attr_value>(?:[^' + SPACE_CHARS + rb'>/]|/(?![' + SPACE_CHARS + rb']*>))++)'
+DOUBLE_QUOTED_ATTR_VAL = rb'"(?<attr_value>(?:[^">/]|/(?![' + SPACE_CHARS + rb']*>))*)"?'
+SINGLE_QUOTED_ATTR_VAL = rb'\'(?<attr_value>(?:[^\'>/]|/(?![' + SPACE_CHARS + rb']*>))*)\'?'
 # May include character references, but for now, ignore the fact that they
 # cannot contain an ambiguous ampersand.
 ATTR_VAL = (


### PR DESCRIPTION
@5j9 When I show you a page with testcases relevant for the issue I discovered, use them for testing! Your last update does not parse correctly all the tags. Once again —I insist—, I'll send you the link with the text I'm interested to use as testcases: [https://meta.wikimedia.org/wiki/User:Tmagc/Sandbox](https://meta.wikimedia.org/wiki/User:Tmagc/Sandbox). I'll attach [a file also if you don't have access to the URL](https://github.com/user-attachments/files/29154743/test2.py). Compare how MW parses it with your current code. I propose a solution. Either you like it or not, fix the problem of tag parsing once and for all and check the testcases I sent are parsed correctly.

