### PR TITLE
A three-by-one issue solution PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dev/profiles/*results*
+**/__pycache__/

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pytest import mark
 
-import sys
-sys.path.append("../wikitextparser")
 from wikitextparser import WikiText, parse
 
 # noinspection PyProtectedMember
@@ -392,28 +390,26 @@ def test_nested_wikilinks_in_ref():
     } == bpts(b'<ref>[[File:Example.jpg|thumb|[[Link]]]]</ref>')
 
 
-@mark.xfail
 def test_invalid_nested_wikilinks():
+    assert {
+        'Parameter': [],
+        'ParserFunction': [],
+        'Template': [],
+        'WikiLink': [[5, 10]],
+        'Comment': [],
+        'ExtensionTag': [],
+    } == bpts(b'[[L| [[S]] ]]')
+
+
+def test_invalid_nested_wikilinks_in_ref():
     assert {
         'Parameter': [],
         'ParserFunction': [],
         'Template': [],
         'WikiLink': [[10, 15]],
         'Comment': [],
-        'ExtTag': [[0, 24]],
+        'ExtensionTag': [[0, 24]],
     } == bpts(b'<ref>[[L| [[S]] ]]</ref>')
-
-
-@mark.xfail
-def test_invalid_nested_wikilinks_in_ref():
-    assert {
-        'Parameter': [],
-        'ParserFunction': [],
-        'Template': [],
-        'WikiLink': [[0, 13]],
-        'Comment': [],
-        'ExtTag': [],
-    } == bpts(b'[[L| [[S]] ]]')
 
 
 def test_nested_parser_functions_containing_param():

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pytest import mark
 
+import sys
+sys.path.append("../wikitextparser")
 from wikitextparser import WikiText, parse
 
 # noinspection PyProtectedMember

--- a/tests/wikitext/test_sections.py
+++ b/tests/wikitext/test_sections.py
@@ -140,3 +140,11 @@ def test_crlf():
     sections_lf = parse(wt.replace('\r', '')).sections
     for s_crlf, s_lf in zip(sections_crlf, sections_lf):
         assert s_crlf.string.replace('\r', '') == s_lf.string
+
+def test_text_outside_section_delimiter():
+    w = WikiText('== title == bjkbhj')
+    assert len(w.get_sections(level=2)) == 0
+
+def test_comment_outside_section_delimiter():
+    w = WikiText('<!-- text --><!-- text -->== title == <!-- text -->   <!-- text --><!-- text -->')
+    assert len(w.get_sections(level=2)) == 1

--- a/wikitextparser/_section.py
+++ b/wikitextparser/_section.py
@@ -4,7 +4,7 @@ from regex import Match
 
 from ._wikitext import SubWikiText, rc
 
-HEADER_MATCH = rc(rb'(={1,6})([^\n]+?)\1[ \t]*(\n|\Z)').match
+HEADER_MATCH = rc(rb'\0*+(={1,6})([^\n]+?)\1[ \t\0]*+(\n|\Z)').match
 
 
 class Section(SubWikiText):

--- a/wikitextparser/_spans.py
+++ b/wikitextparser/_spans.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import partial
 from typing import Callable, Dict, List, Union
 
-from regex import DOTALL, IGNORECASE, REVERSE, Match, compile as rc
+from regex import DOTALL, IGNORECASE, REVERSE, Match, compile as rc, search
 
 from ._config import (
     _HTML_TAG_NAME,
@@ -361,7 +361,8 @@ def _parse_sub_spans(
             for match in WIKILINK_PARAM_FINDITER(byte_array, start, end):
                 ms, me = match.span()
                 if match[1] is None:
-                    wls_append([ms, me, match, byte_array[ms:me]])
+                    if search(rb"^\[\[[ \t]*+(?:File|Image)[ \t]*+:", match[0], IGNORECASE) or not search(rb"\x02\x02", match[0], IGNORECASE):
+                        wls_append([ms, me, match, byte_array[ms:me]])
                     _parse_sub_spans(
                         byte_array,
                         ms + 2,

--- a/wikitextparser/_wikitext.py
+++ b/wikitextparser/_wikitext.py
@@ -67,8 +67,8 @@ INVALID_EL_TPP_CHRS_SUB = rc(  # the [:-4] slice allows \[ and \]
 ).sub
 
 # Sections
-SECTION_HEADING = rb'^(?<equals>={1,6})[^\r\n]+?(?P=equals)[ \t]*+\r?+$'
-SUB_SECTION = rb'(?:^(?P=equals)=[^\r\n]+?(?P=equals)=[ \t]*+\r?+$.*?)*'
+SECTION_HEADING = rb'^\0*+(?<equals>={1,6})[^\r\n]+?(?P=equals)[ \t\0]*+\r?+$'
+SUB_SECTION = rb'(?:^\0*+(?P=equals)=[^\r\n]+?(?P=equals)=[ \t\0]*+\r?+$.*?)*'
 LEAD_SECTION = rb'(?<section>(?<equals>).*?)'
 SECTIONS_FULLMATCH = rc(
     LEAD_SECTION
@@ -1697,7 +1697,7 @@ plain_text_doc = """
         :keyword replace_parser_functions:
             A function mapping `ParserFunction` objects to strings.
             If True, replace `{{#parser_function:argument}}`s with `''`.
-            If False, ignore parser functions. 
+            If False, ignore parser functions.
         :keyword replace_parameters: Replace `{{{a}}}` with `` and {{{a|b}}}
             with `b`.
         :keyword replace_tags: Replace `<s>text</s>` with `text`.


### PR DESCRIPTION
Let's talk bout three problems I've been adressing today:

1. **fixed section heading parsing**: If you have comments before or after your section title, the header remains valid. This isn't what happens in current version. Modified regex and added the comment wildcard (\0) to be detected on the parsing. Added two additional tests to verify.
2. **a solution for the nested link problem**: A nested link is invalid unless we are talinkg about an image link. Therefore, in [[a|[[b]]]], [[b]] is the link while the outer brackets will be ignored. On the other hand, in [[File:a.jpg|[[b]]]] both inner and outer brackets must be taken into account. What I did? just wls_append a link if and only if it starts with "File:" or "Image:" OR there are no new link begginings inside ([[). Of course I'd extend this to every language but I don't know where I can find a database with all the equivalences between site namespaces and aliases. I think it's fine for now to leave this as such.
3. **add __pycache__ to gitignore**, and I think isn't very professional to leave .vscode exposed on repository. There might be other Python stuff that might be convenient to add too.

If there isn't any opposition, let there be merge.